### PR TITLE
Eo p devel

### DIFF
--- a/EOverPCalibration/src/FastCalibratorEB.cc
+++ b/EOverPCalibration/src/FastCalibratorEB.cc
@@ -121,8 +121,6 @@ void FastCalibratorEB::Init(TTree *tree){
   fChain->SetBranchStatus("runNumber", 1);   fChain->SetBranchAddress("runNumber", &runNumber, &b_runNumber);
   fChain->SetBranchStatus("lumiBlock", 1);  fChain->SetBranchAddress("lumiBlock", &lumiBlock, &b_lumiBlock);
   fChain->SetBranchStatus("eventNumber", 1); fChain->SetBranchAddress("eventNumber", &eventNumber, &b_eventNumber);
-  fChain->SetBranchStatus("isW", 1);     fChain->SetBranchAddress("isW", &isW, &b_isW);
-  fChain->SetBranchStatus("isZ", 1);     fChain->SetBranchAddress("isZ", &isZ, &b_isZ);
   
   fChain->SetBranchStatus("chargeEle", 1);             fChain->SetBranchAddress("chargeEle", chargeEle);
   fChain->SetBranchStatus("etaEle", 1);             fChain->SetBranchAddress("etaEle", &etaEle, &b_etaEle);
@@ -134,7 +132,6 @@ void FastCalibratorEB::Init(TTree *tree){
   fChain->SetBranchStatus("esEnergySCEle", 1);             fChain->SetBranchAddress("esEnergySCEle", &esEnergySCEle, &b_esEnergySCEle);
   fChain->SetBranchStatus("pAtVtxGsfEle", 1);             fChain->SetBranchAddress("pAtVtxGsfEle", &pAtVtxGsfEle, &b_pAtVtxGsfEle);
   fChain->SetBranchStatus("fbremEle", 1);             fChain->SetBranchAddress("fbremEle", &fbremEle, &b_fbremEle);
-  fChain->SetBranchStatus("isEBEle", 1);             fChain->SetBranchAddress("isEBEle", &isEBEle, &b_isEBEle);
   fChain->SetBranchStatus("energyMCEle", 1);             fChain->SetBranchAddress("energyMCEle", &energyMCEle, &b_energyMCEle);
   fChain->SetBranchStatus("etaMCEle", 1);             fChain->SetBranchAddress("etaMCEle", &etaMCEle, &b_etaMCEle);
   fChain->SetBranchStatus("phiMCEle", 1);             fChain->SetBranchAddress("phiMCEle", &phiMCEle, &b_phiMCEle);
@@ -229,9 +226,9 @@ void FastCalibratorEB::BuildEoPeta_ele(int iLoop, int nentries , int useW, int u
 
    float pIn, FdiEta;
 
-   ///! Tight electron from W or Z only barrel
+   ///! Tight electron from W or Z only barrel (if chargeEle[1]==0: event from W)
    
-   if ( isEBEle[0] == 1 && (( useW == 1 && isW == 1 ) ||  ( useZ== 1 && isZ == 1 ))) {
+   if ( fabs(etaSCEle[0]) < 1.479 && (( useW == 1 && chargeEle[1]==0 ) ||  ( useZ== 1 && chargeEle[1]!=0 ))) {
 
     FdiEta = energySCEle[0]/rawEnergySCEle[0]; /// FEta approximation
     
@@ -309,7 +306,7 @@ void FastCalibratorEB::BuildEoPeta_ele(int iLoop, int nentries , int useW, int u
   }
   ///=== Second medium electron from Z
   
-  if ( isEBEle[1] == 1 && (( useW == 1 && isW == 1 ) || ( useZ == 1 && isZ == 1 )) ){
+   if ( fabs(etaSCEle[1]) < 1.479 && ( useZ == 1 && chargeEle[1]!=0 ) ){
 
     FdiEta = energySCEle[1]/rawEnergySCEle[1]; /// FEta approximation
  
@@ -519,9 +516,9 @@ void FastCalibratorEB::Loop( int nentries, int useZ, int useW, int splitStat, in
         std::map<int,double> map;
         bool skipElectron=false;
        
-        /// Tight electron information from W and Z, it depends on the flag variable isW, isZ
-	
-        if ( isEBEle[0] == 1 && (( useW == 1 && isW == 1 ) || ( useZ == 1 && isZ == 1 )) ) {
+        /// Tight electron information from W and Z
+
+        if ( fabs(etaSCEle[0]) < 1.479 && (( useW == 1 && chargeEle[1]==0 ) || ( useZ == 1 && chargeEle[1]!=0 )) ) {
                   
          /// SCL energy containment correction
           FdiEta = energySCEle[0]/rawEnergySCEle[0];
@@ -646,7 +643,7 @@ void FastCalibratorEB::Loop( int nentries, int useZ, int useW, int splitStat, in
         skipElectron = false;
       
         /// Ele2 medium from Z only Barrel
-        if ( isEBEle[1] == 1 && (( useW == 1 && isW == 1 ) || ( useZ == 1 && isZ == 1 )) ) {
+        if ( fabs(etaSCEle[1]) < 1.479 && ( useZ == 1 && chargeEle[1]!=0 ) ) {
   
           FdiEta = energySCEle[1]/rawEnergySCEle[1];
           // Electron energy

--- a/EOverPCalibration/src/FastCalibratorEE.cc
+++ b/EOverPCalibration/src/FastCalibratorEE.cc
@@ -127,8 +127,6 @@ void FastCalibratorEE::Init(TTree *tree){
   fChain->SetBranchStatus("runNumber", 1);   fChain->SetBranchAddress("runNumber", &runNumber, &b_runNumber);
   fChain->SetBranchStatus("lumiBlock", 1);  fChain->SetBranchAddress("lumiBlock", &lumiBlock, &b_lumiBlock);
   fChain->SetBranchStatus("eventNumber", 1); fChain->SetBranchAddress("eventNumber", &eventNumber, &b_eventNumber);
-  fChain->SetBranchStatus("isW", 1);     fChain->SetBranchAddress("isW", &isW, &b_isW);
-  fChain->SetBranchStatus("isZ", 1);     fChain->SetBranchAddress("isZ", &isZ, &b_isZ);
   
   fChain->SetBranchStatus("chargeEle", 1);             fChain->SetBranchAddress("chargeEle", chargeEle);
   fChain->SetBranchStatus("etaEle", 1);             fChain->SetBranchAddress("etaEle", &etaEle, &b_etaEle);
@@ -140,7 +138,6 @@ void FastCalibratorEE::Init(TTree *tree){
   fChain->SetBranchStatus("esEnergySCEle", 1);             fChain->SetBranchAddress("esEnergySCEle", &esEnergySCEle, &b_esEnergySCEle);
   fChain->SetBranchStatus("pAtVtxGsfEle", 1);             fChain->SetBranchAddress("pAtVtxGsfEle", &pAtVtxGsfEle, &b_pAtVtxGsfEle);
   fChain->SetBranchStatus("fbremEle", 1);             fChain->SetBranchAddress("fbremEle", &fbremEle, &b_fbremEle);
-  fChain->SetBranchStatus("isEBEle", 1);             fChain->SetBranchAddress("isEBEle", &isEBEle, &b_isEBEle);
   fChain->SetBranchStatus("energyMCEle", 1);             fChain->SetBranchAddress("energyMCEle", &energyMCEle, &b_energyMCEle);
   fChain->SetBranchStatus("etaMCEle", 1);             fChain->SetBranchAddress("etaMCEle", &etaMCEle, &b_etaMCEle);
   fChain->SetBranchStatus("phiMCEle", 1);             fChain->SetBranchAddress("phiMCEle", &phiMCEle, &b_phiMCEle);
@@ -245,7 +242,7 @@ void FastCalibratorEE::BuildEoPeta_ele(int iLoop, int nentries , int useW, int u
 
    float pIn, FdiEta;
    ///=== electron tight W or Z only Endcap
-   if ( isEBEle[0] == 0 && (( useW == 1 && isW == 1 ) ||  ( useZ== 1 && isZ == 1 ))) {
+   if ( fabs(etaSCEle[0]) >= 1.479 && (( useW == 1 && chargeEle[1]==0 ) ||  ( useZ== 1 && chargeEle[1]!=0 ))) {
 
     FdiEta = energySCEle[0]/(rawEnergySCEle[0]+esEnergySCEle[0]); /// Cluster containment approximation using ps infos
    
@@ -324,7 +321,7 @@ void FastCalibratorEE::BuildEoPeta_ele(int iLoop, int nentries , int useW, int u
   }
 
   ///=== Second medium electron from Z only Endcaps
-  if ( isEBEle[1] == 0 && (( useW == 1 && isW == 1 ) || ( useZ == 1 && isZ == 1 )) ){
+  if ( fabs(etaSCEle[1]) >= 1.479 && ( useZ== 1 && chargeEle[1]!=0 )) {
 
     FdiEta = energySCEle[1]/(rawEnergySCEle[1]+esEnergySCEle[1]);
 
@@ -521,7 +518,7 @@ void FastCalibratorEE::Loop( int nentries, int useZ, int useW, int splitStat, in
 	
         /// Only tight electron from W and Z, only Endcap
         
-	if ( isEBEle[0] == 0 && (( useW == 1 && isW == 1 ) || ( useZ == 1 && isZ == 1 )) ) {
+	if ( fabs(etaSCEle[0]) >= 1.479 && (( useW == 1 && chargeEle[1]==0 ) ||  ( useZ== 1 && chargeEle[1]!=0 ))) {
                   
           /// SCL energy containment correction
           FdiEta = energySCEle[0]/(rawEnergySCEle[0]+esEnergySCEle[0]);
@@ -690,7 +687,7 @@ void FastCalibratorEE::Loop( int nentries, int useZ, int useW, int splitStat, in
         
         
 	/// Medium ele from Z only Endcap
-        if( isEBEle[1] == 0 && ( useZ == 1 && isZ == 1 ) ){
+	if ( fabs(etaSCEle[1]) >= 1.479 && ( useZ== 1 && chargeEle[1]!=0 )) {
           /// SCL energy containment correction
           FdiEta = energySCEle[1]/(rawEnergySCEle[1]+esEnergySCEle[1]);
          

--- a/ZFitter/data/validation/EoverPcalibration.dat
+++ b/ZFitter/data/validation/EoverPcalibration.dat
@@ -1,4 +1,6 @@
 #################input list for the E/p calibration ############################
 #d    selected            /afs/cern.ch/user/l/lbrianza/work/public/ntuple_numEvent100.root
 #d    extraCalibTree      /afs/cern.ch/user/l/lbrianza/work/public/extraCalibTree.root
-d    selected            /afs/cern.ch/user/l/lbrianza/work/public/RUND_DoubleElectron.root
+#d    selected            /afs/cern.ch/user/l/lbrianza/work/public/RUND_DoubleElectron.root
+d    selected            /afs/cern.ch/user/l/lbrianza/work/public/ntuple_numEvent100.root
+d    extraCalibTree            /afs/cern.ch/user/l/lbrianza/work/public/extraCalibTree.root

--- a/ZNtupleDumper/src/ZNtupleDumper.cc
+++ b/ZNtupleDumper/src/ZNtupleDumper.cc
@@ -225,7 +225,6 @@ private:
   Int_t  chargeEle[2];
   Float_t etaSCEle[2], phiSCEle[2]; ///< phi of the SC
   Float_t   etaEle[2],   phiEle[2]; ///< phi of the electron (electron object)
-  Int_t isEBEle[2];
 
   Int_t recoFlagsEle[2];           ///< 1=trackerDriven, 2=ecalDriven only, 3=tracker and ecal driven
 
@@ -343,8 +342,6 @@ private:
   std::vector<float>     LCRecHitSCEle[2];
   std::vector<float>     ICRecHitSCEle[2];
   std::vector<float>  AlphaRecHitSCEle[2];
-  Int_t isW;
-  Int_t isZ;
 
   //==============================
 
@@ -659,8 +656,6 @@ void ZNtupleDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   }
   
   bool doFill=false;
-  isW=0;
-  isZ=0;
   if(eventType==PARTGUN){
     pat::ElectronCollection::const_iterator eleIter1 = electronsHandle->begin();
     pat::ElectronCollection::const_iterator eleIter2 = eleIter1;
@@ -707,7 +702,6 @@ void ZNtupleDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 	if( eleIter1->et()<30) continue;
 
 	doFill=true;	
-        isW=1; 
 	if(eventType==UNKNOWN) eventType=WENU;
 	TreeSetSingleElectronVar(*eleIter1, 0);  //fill first electron 
 	TreeSetSingleElectronVar(*eleIter1, -1); // fill fake second electron
@@ -732,7 +726,6 @@ void ZNtupleDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 	  if((mass < 55 || mass > 125)) continue;
 	  
 	  doFill=true;
-          isZ=1;
 	if(eventType==UNKNOWN) eventType=ZEE;
 	  TreeSetDiElectronVar(*eleIter1, *eleIter2);
 	  
@@ -812,7 +805,6 @@ void ZNtupleDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     // save the event in the tree
     if(HighEtaSC1!= EESuperClustersHandle->end()){
       doFill=true;
-      isZ=1;
       TreeSetDiElectronVar(*PatEle1, *HighEtaSC1);
       if(doExtraCalibTree){
 	TreeSetExtraCalibVar(*PatEle1, *HighEtaSC1);
@@ -1227,7 +1219,6 @@ void ZNtupleDumper::TreeSetSingleElectronVar(const pat::Electron& electron1, int
     chargeEle[-index] = 0;
     etaEle[-index]    = 0; 
     phiEle[-index]    = 0;
-    isEBEle[-index]   = 0;
     return;
   }   
 
@@ -1235,7 +1226,6 @@ void ZNtupleDumper::TreeSetSingleElectronVar(const pat::Electron& electron1, int
   chargeEle[index] = electron1.charge();
   etaEle[index]    = electron1.eta(); // degli elettroni
   phiEle[index]    = electron1.phi();
-  isEBEle[-index]   = electron1.isEB();
 
 
   if(electron1.ecalDrivenSeed()){
@@ -1417,7 +1407,6 @@ void ZNtupleDumper::TreeSetSingleElectronVar(const reco::SuperCluster& electron1
     chargeEle[-index] = 0;
     etaEle[-index]    = 0;
     phiEle[-index]    = 0;
-    isEBEle[-index]   = 0;
     return;
   }
 
@@ -1427,7 +1416,6 @@ void ZNtupleDumper::TreeSetSingleElectronVar(const reco::SuperCluster& electron1
   chargeEle[index] = -100; // dont know the charge for SC
   etaEle[index]    = electron1.eta(); // eta = etaSC
   phiEle[index]    = electron1.phi();
-  isEBEle[index]   = -100;
 
   recoFlagsEle[index] = -1; // define -1 as a SC
 
@@ -1772,10 +1760,6 @@ void ZNtupleDumper::InitExtraCalibTree(){
   extraCalibTree->Branch("AlphaRecHitSCEle1", &(AlphaRecHitSCEle[0]));
   extraCalibTree->Branch("AlphaRecHitSCEle2", &(AlphaRecHitSCEle[1]));
 
-  extraCalibTree->Branch("isW",&isW, "isW/I");
-  extraCalibTree->Branch("isZ",&isZ, "isZ/I");
-  extraCalibTree->Branch("isEBEle",&isEBEle, "isEBEle[2]/I");
-
   return;
 }
 
@@ -1808,7 +1792,6 @@ void ZNtupleDumper::TreeSetExtraCalibVar(const pat::Electron& electron1, int ind
   //  EcalIntercalibConstantMap icMap = icHandle->get()
   std::vector< std::pair<DetId, float> > hitsAndFractions_ele1 = electron1.superCluster()->hitsAndFractions();
   nHitsSCEle[index] = hitsAndFractions_ele1.size();
-  isEBEle[index] = electron1.isEB();
   
   const EcalRecHitCollection *recHits = (electron1.isEB()) ?  clustertools->getEcalEBRecHitCollection() : clustertools->getEcalEERecHitCollection();
   const EcalIntercalibConstantMap& icalMap = clustertools->getEcalIntercalibConstants();


### PR DESCRIPTION
forgot to include in the previous pull request some modifications of the classes FastCalibratorEB and EE: totally removed isW, isZ and isEBEle variables from the .cc