### PR TITLE
Solve ZFitter dependencies

### DIFF
--- a/ZFitter/MakeVars
+++ b/ZFitter/MakeVars
@@ -22,14 +22,15 @@ ROOSTAT_LIB="-lRooStats"
 
 
 INCLUDEDIR=./interface
+FWCORE_INCLUDE=$(CMSSW_BASE)/src
 SRCDIR=./src
 BUILDDIR=./bin
 OBJ_DIR=./lib
 
 EoPDir:=../EOverPCalibration
-
+SCRAM_ARCH=`scram arch`
 #################
-INCLUDE=-I$(INCLUDEDIR) -isystem$(ROOT_INCLUDE)   -I$(ROOFIT_INCLUDE) -I$(BOOST)/include
+INCLUDE=-I$(INCLUDEDIR) -I$(FWCORE_INCLUDE) -isystem$(ROOT_INCLUDE)   -I$(ROOFIT_INCLUDE) -I$(BOOST)/include
 LIB=-L$(BOOST)/lib -L/usr/lib64 # -L/usr/lib 
 
 

--- a/ZFitter/Makefile
+++ b/ZFitter/Makefile
@@ -2,10 +2,11 @@ include MakeVars
 
 #### Make the list of modules from the list of .cc files in the SRC directory
 MODULES=$(shell ls $(SRCDIR)/*.cc | sed "s|.cc|.o|;s|$(SRCDIR)|$(OBJ_DIR)|g")
+MODULES_EXT="$(CMSSW_BASE)/lib/$(SCRAM_ARCH)/"
 MODULESEoP=$(shell ls $(EoPDir)/$(SRCDIR)/*.cc | sed "s|.cc|.o|;s|$(SRCDIR)|$(OBJ_DIR)|g")
 #### Make the list of dependencies for a particular module
 
-default: $(MODULES)  ZFitter.exe
+default: $(MODULES) ZFitter.exe
 
 #------------------------------ MODULES (static libraries)
 
@@ -15,10 +16,10 @@ MAKEDEPEND = -MMD  -MT '$@ lib/$*.d'
 #### General rule for classes (libraries) compiled statically
 ### Generate also a .d file with prerequisites
 lib/%.o: $(SRCDIR)/%.cc
-	@echo "--> Making $@" 
+	@echo "--> Making $@"
+	@echo "--> Making $(MODULES_EXT)" 
 	echo $(INCLUDE)
-	@$(COMPILE.cc) $(CXXFLAGS) $(INCLUDE) $(MAKEDEPEND) -o $@ $<
-
+	@$(COMPILE.cc) $(CXXFLAGS) $(INCLUDE) $(MAKEDEPEND) -o $@ $< -L$(MODULES_EXT)
 
 -include $(MODULES:.o=.d)
 
@@ -32,7 +33,7 @@ ZFitter.exe: $(BUILDDIR)/ZFitter.exe
 $(BUILDDIR)/ZFitter.exe:  $(BUILDDIR)/ZFitter.cpp 
 	cd $(EoPDir) && make
 	@echo "---> Making ZFitter $(COMPILE.exe)"
-	@g++ $(CXXFLAGS) $(INCLUDE) $(MAKEDEPEND) -o $@ $< $(MODULES) $(MODULESEoP) $(LIB) $(ROOT_LIB) $(ROOFIT_LIB) $(ROOSTAT_LIB) $(ROOT_FLAGS) \
+	@g++ $(CXXFLAGS) $(INCLUDE) $(MAKEDEPEND) -o $@ $< $(MODULES) $(MODULES_EXT)/libFWCoreParameterSet.so $(MODULESEoP) $(LIB) $(ROOT_LIB) $(ROOFIT_LIB) $(ROOSTAT_LIB) $(ROOT_FLAGS) \
 	-lboost_program_options -lTreePlayer 
 
 clean:

--- a/setup_git.sh
+++ b/setup_git.sh
@@ -184,16 +184,14 @@ case $CMSSW_VERSION in
 	git cms-merge-topic -u ldcorpe:topic-ecalelf-alcareco-streams
 	;;
 	CMSSW_7_6_*)
-		git cms-merge-topic shervin86:76X || exit 1
-		;;
+	    git cms-merge-topic shervin86:76X || exit 1
+	    ;;
 	CMSSW_8_0_*)
-		git cms-merge-topic shervin86:fix80X || exit 1
-		;;
-
+	    git cms-addpkg FWCore/ParameterSet
+	    git cms-merge-topic shervin86:fix80X || exit 1
+	    ;;
 
 esac
-
-
 
 # compile
 scram b -j16


### PR DESCRIPTION
- Add cms packages FWCore/ParameterSet on the setup script
- Include the libFWCoreParameterSet.so to the ZFitter makefile