### PR TITLE
Crab3 submission tool

### DIFF
--- a/EcalAlCaRecoProducers/README.md
+++ b/EcalAlCaRecoProducers/README.md
@@ -1,6 +1,80 @@
 # Producing `ECALELF NTuples` for Calibration
 
-# old instructions
+*The following instructions work using `MiniAOD` dataset*
+
+* To start the n-tuple production, movee to :
+```bash 
+cd ${CMSSW_BASE}/Calibration/EcalAlCaRecoProducers
+```
+
+* Setup `crab3` environment
+```bash
+source ../initCmsEnvCRAB.sh
+```
+
+* Select a JSON that contains the runs that you are willing to run. A new JSON is published every Friday and can be found on `lxplus` machines on `/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/`  or online on this [link](https://cms-service-dqm.web.cern.ch/cms-service-dqm/CAF/certification/Collisions16/13TeV/)
+
+* On the configuration file `alcareco_datasets.dat` you have to add mainly the location of the dataset on the `DAS` and the run range. For example:
+```org
+281613-282037 /DoubleEG/Run2016H-PromptReco-v2/MINIAOD DoubleEG-Run2016H-noSkim-Prompt_v2-miniAOD caf database VALID RUN2016H
+```
+
+* The most important columns here are the run-range, the dataset bath on the `DAS` and the name you want to give to you dataset on the `eos`, `DoubleEG-Run2016H-noSkim-Prompt_v2-miniAOD` in the example. Be sure that the run-range that you are running on is in the JSON file. 
+
+* The next step will be to run the `prod_ntuples.py`. The script will create a directory `crab-submit-{ERA}-{RUN-RANGE}` containing a skimmed JOSN file with run in the selected `RUN-RANGE` and a `crab3` configuration to be submitted by `crab submit -c crab-submit-{ERA}-{RUN-RANGE}/crab_crab-{RUN-RANGE}-{ERA}.py`. Example of command :
+```bash 
+python prod_ntuples.py -j Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt -r "281613-282037" -q False --name PromtReco -g config/reRecoTags/80X_dataRun2_Prompt_v12.py
+
+crab sumbit -c crab-submit-Run2016H-281613-282037/crab_crab-281613-282037-Run2016H.py
+```
+
+* The full list of `prod_ntuples.py` options can be displayed by typing `python prod_ntuples.py --help` :
+```bash 
+[user@lxplus] python prod_ntuples.py --help
+
+Usage: prod_ntuples.py [options]
+
+Options:
+  -h, --help            show this help message and exit
+  -j FILE, --json-file=FILE
+                        specify the JSON file
+  -r RUN_RANGE, --run-range=RUN_RANGE
+                                               Specify the run range. This
+                        must be present in the input
+                        JSON file, and in the dataset file. The range shoud be
+                        specified for example as :
+                        --run-range "281613-282037"
+  -n NAME, --name=NAME                         name given to the job
+  -q RUN_ON_CAF, --run-on-caf=RUN_ON_CAF
+                                               Option allowing CRAB jobs to
+                        run on CAF queues:                       If you want
+                        to choose a specific site you can edit
+                        the generated crab config file
+  -d FILE, --dataset-file=FILE
+                                               dataset file containing the
+                        information about the run range:
+                        example :                       | run-range | dataset
+                        path | store path radical in eos | storing unit |
+                        ......                       281613-282037
+                        /DoubleEG/Run2016H-PromptReco-v2/MINIAOD DoubleEG-
+                        Run2016H-noSkim-Prompt_v2-miniAOD caf database VALID
+                        RUN2016H
+  -g FILE, --global-tag=FILE
+                                               Global Tag to the corresponding
+                        dataset :                       example :
+                        config/reRecoTags/80X_dataRun2_Prompt_v12.py
+  -t TYPE, --type=TYPE                         Type of the ntuple :
+                        MINIAODNTUPLE
+  --create-only=CREATE_ONLY
+                        This will crate JSON file and crab3 config file
+                        without submission
+  --submit=SUBMIT       This will crate JSON file and crab3 config files and
+                        proceseed to submission:                       This
+                        command is equivalent of running : crab python/
+
+```
+
+# Depricated instructions
 * Girare in locale (funziona)
 ```
 ##DATI

--- a/EcalAlCaRecoProducers/README.md
+++ b/EcalAlCaRecoProducers/README.md
@@ -1,15 +1,6 @@
 # Producing `ECALELF NTuples` for Calibration
-## using the `MiniAOD`
-Starting from `CMSSW_8_0_22` crab3 can be used to send jobs on the grid. A solution exist on how to run on the  `CAF` queues via CERN.
 
-
-
-
-
-
-
-
-# Italian Version
+# old instructions
 * Girare in locale (funziona)
 ```
 ##DATI

--- a/EcalAlCaRecoProducers/README.md
+++ b/EcalAlCaRecoProducers/README.md
@@ -1,3 +1,15 @@
+# Producing `ECALELF NTuples` for Calibration
+## using the `MiniAOD`
+Starting from `CMSSW_8_0_22` crab3 can be used to send jobs on the grid. A solution exist on how to run on the  `CAF` queues via CERN.
+
+
+
+
+
+
+
+
+# Italian Version
 * Girare in locale (funziona)
 ```
 ##DATI

--- a/EcalAlCaRecoProducers/alcareco_datasets.dat
+++ b/EcalAlCaRecoProducers/alcareco_datasets.dat
@@ -244,27 +244,22 @@ allRange	/DYToEE_NNPDF30_13TeV-powheg-pythia8/RunIISpring16MiniAODv1-PUSpring16_
 276315-276585	/DoubleEG/Run2016D-EcalCalZElectron-PromptReco-v2/ALCARECO DoubleEG-Run2016D-ZSkim-Prompt_v2          caf database VALID RUN2016D
 #276315-276585	/DoubleEG/Run2016D-PromptReco-v2/AOD                       DoubleEG-Run2016D-ZSkim-Prompt_v2          caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco VALID RUN2016D
 276315-276585	/DoubleEG/Run2016D-PromptReco-v2/MINIAOD                   DoubleEG-Run2016D-noSkim-Prompt_v2-miniAOD  caf database VALID RUN2016D
-####
-###### MC LT Binned for Hgg linearity studies
-allRange	/DYJetsToEE_M-50_LTbinned_5To75_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_5To75-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_75To80_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_75To80-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_80To85_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_80To85-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_85To90_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_85To90-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_90To95_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_90To95-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_95To100_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_95To100-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_100To200_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_100To200-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_200To400_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_200To400-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_400To800_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_400To800-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
-allRange	/DYJetsToEE_M-50_LTbinned_800To2000_5f_LO_13TeV-madgraph_pythia8/RunIISpring16DR80-PUSpring16_80X_mcRun2_asymptotic_2016_v3-v1/AODSIM DYJets_madgraph-LT_800To2000-RunIISpring16DR80   caf group/dpg_ecal/alca_ecalcalib/ecalelf/alcareco	 VALID - -
 
-###### MC LT Binned for Hgg linearity studies (MINIAOD samples)#######################
-allRange 	/DYJetsToEE_M-50_LTbinned_5To75_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_5To75 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_75To80_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_75To80 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_80To85_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_80To85 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_85To90_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_85To90 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_90To95_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_90To95 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_95To100_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_95To100 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_100To200_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_100To200 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_200To400_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_200To400 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_400To800_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_400To800 caf database VALID - - 
-allRange 	/DYJetsToEE_M-50_LTbinned_800To2000_5f_LO_13TeV-madgraph_pythia8/RunIISpring16MiniAODv2-PUSpring16_80X_mcRun2_asymptotic_2016_miniAODv2_v0-v1/MINIAODSIM DYJetsToEE_M-50_LTbinned_800To2000 caf database VALID - - 
+# with new laser correction, new prompt tag v10
+275657-276283	 /DoubleEG/Run2016C-PromptReco-v2/MINIAOD	DoubleEG-Run2016C-noSkim-Prompt_v2-miniAOD  caf database VALID RUN2016C
+276315-276811	 /DoubleEG/Run2016D-PromptReco-v2/MINIAOD	DoubleEG-Run2016D-noSkim-Prompt_v2-miniAOD  caf database VALID RUN2016D
+276831-277420	 /DoubleEG/Run2016E-PromptReco-v2/MINIAOD	DoubleEG-Run2016E-noSkim-Prompt_v2-miniAOD  caf database VALID RUN2016E
+277981-278808	 /DoubleEG/Run2016F-PromptReco-v1/MINIAOD       DoubleEG-Run2016F-noSkim-Prompt_v1-miniAOD  caf database VALID RUN2016F
+278820-279588	 /DoubleEG/Run2016G-PromptReco-v1/MINIAOD       DoubleEG-Run2016G-noSkim-Prompt_v1-miniAOD  caf database VALID RUN2016G
+279653-280385	 /DoubleEG/Run2016G-PromptReco-v1/MINIAOD       DoubleEG-Run2016G-noSkim-Prompt_v1-miniAOD  caf database VALID RUN2016G
+281613-282037	 /DoubleEG/Run2016H-PromptReco-v2/MINIAOD       DoubleEG-Run2016H-noSkim-Prompt_v2-miniAOD  caf database VALID RUN2016H
+
+# Sept23 rereco
+
+272007-272785 /DoubleEG/Run2016B-23Sep2016-v2/MINIAOD  DoubleEG-Run2016B-noSkim-3Sep2016-v2-miniAOD  caf database VALID RUN2016B
+274198-275376 /DoubleEG/Run2016B-23Sep2016-v3/MINIAOD  DoubleEG-Run2016B-noSkim-3Sep2016-v3-miniAOD  caf database VALID RUN2016B
+275657-276283 /DoubleEG/Run2016C-23Sep2016-v1/MINIAOD  DoubleEG-Run2016C-noSkim-3Sep2016-v1-miniAOD  caf database VALID RUN2016C
+276315-276811 /DoubleEG/Run2016D-23Sep2016-v1/MINIAOD  DoubleEG-Run2016D-noSkim-3Sep2016-v1-miniAOD  caf database VALID RUN2016D
+276831-277420 /DoubleEG/Run2016E-23Sep2016-v1/MINIAOD  DoubleEG-Run2016E-noSkim-3Sep2016-v1-miniAOD  caf database VALID RUN2016E
+277772-278808 /DoubleEG/Run2016F-23Sep2016-v1/MINIAOD  DoubleEG-Run2016F-noSkim-3Sep2016-v1-miniAOD  caf database VALID RUN2016F
+278820-280385 /DoubleEG/Run2016G-23Sep2016-v1/MINIAOD  DoubleEG-Run2016G-noSkim-3Sep2016-v1-miniAOD  caf database VALID RUN2016G

--- a/EcalAlCaRecoProducers/config/reRecoTags/80X_dataRun2_2016SeptRepro_v4.py
+++ b/EcalAlCaRecoProducers/config/reRecoTags/80X_dataRun2_2016SeptRepro_v4.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+RerecoGlobalTag = cms.ESSource("PoolDBESSource",
+                               CondDBSetup,
+                               connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+                               globaltag = cms.string('80X_dataRun2_2016SeptRepro_v4'),
+)

--- a/EcalAlCaRecoProducers/crab_TEMPLATE.py
+++ b/EcalAlCaRecoProducers/crab_TEMPLATE.py
@@ -1,0 +1,51 @@
+from CRABClient.UserUtilities import config
+import FWCore.ParameterSet.Config as cms
+
+config = config()
+
+config.General.requestName = ''
+config.General.workArea = 'crab_projects'
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.outputFiles= [
+    'ntuple.root'
+    #'ntuple_numEvent1000.root'
+]
+config.JobType.psetName = 'python/alcaSkimming.py'
+config.JobType.pyCfgParams = [
+    'tagFile=config/reRecoTags/80X_dataRun2_Prompt_v12.py',
+    'type=MINIAODNTUPLE',
+    'doTreeOnly=1',
+    'doTree=1',
+    #'jsonFile=TestDontUse_13TeV_PromptReco_JSON_NoL1T.txt',
+    #'jsonFile=RUN2016H-281613-282037_13TeV_PromptReco_JSON_NoL1T.txt',
+    'jsonFile=RUN2016H-282092-284035_13TeV_PromptReco_JSON_NoL1T.txt',
+    'isCrab=1',
+    'isPrivate=0',
+    'bunchSpacing=0']
+config.JobType.inputFiles = [
+    #'TestDontUse_13TeV_PromptReco_JSON_NoL1T.txt',
+    #'RUN2016H-281613-282037_13TeV_PromptReco_JSON_NoL1T.txt'
+    'RUN2016H-282092-284035_13TeV_PromptReco_JSON_NoL1T.txt'
+]
+
+config.JobType.allowUndistributedCMSSW = True
+config.JobType.maxJobRuntimeMin = 2750
+#config.JobType.sendPythonFolder = True
+
+config.Data.inputDataset  = '/DoubleEG/Run2016H-PromptReco-v2/MINIAOD'
+config.Data.inputDBS      = 'global'
+config.Data.splitting     = 'FileBased' #'LumiBased'
+config.Data.unitsPerJob   = 1 #30000
+#config.Data.lumiMask      = 'TestDontUse_13TeV_PromptReco_JSON_NoL1T.txt'
+config.Data.lumiMask      = 'RUN2016H-282092-284035_13TeV_PromptReco_JSON_NoL1T.txt'#'RUN2016H-281613-282037_13TeV_PromptReco_JSON_NoL1T.txt'
+config.Data.runRange      = '282092-284035'#'281613-282037'
+config.Data.outLFNDirBase = '/store/group/dpg_ecal/alca_ecalcalib/ecalelf/ntuples/13TeV/MINIAODNTUPLE/80X_dataRun2_Prompt_v12/DoubleEG-Run2016H-noSkim-Prompt_v2-miniAOD/282092-284035/'
+config.Data.publication   = False
+
+# GRID
+config.Site.storageSite   =  'T2_CH_CERN'
+#config.Site.whitelist     = ['T3_CH_CERN_CAF']
+#config.Site.blacklist     = ['T1_US_FNAL','T2_UA_KIPT','T2_UK_London_Brunel','T2_CH_CSCS','T2_US_*']
+#config.Site.ignoreGlobalBlacklist = True

--- a/EcalAlCaRecoProducers/prod_ntuples.py
+++ b/EcalAlCaRecoProducers/prod_ntuples.py
@@ -1,0 +1,161 @@
+#!/usr/local/bin/python
+# this a submission script fro crab3
+
+import numpy  as np
+import pandas as pd
+import sys, os, csv, re, json, getopt
+from   StringIO import *
+from   pprint   import pprint
+from optparse   import OptionParser
+
+
+def dataset_option(infile,
+                   grep = ["RUN2016D","276315-276811"],
+                   header=["run_range","dataset","eos","scheduler", "type", "validity", "ERA"]):
+    _lines_  = [line for line in open(infile) if not line.startswith('#')]
+    _lines_  = [line.replace('\n','') for line in _lines_]
+    for g in grep:
+        _lines_   = [line for line in _lines_ if g in line ]
+    option = [li for li in _lines_[0].split() if li != '']
+    pprint(option)
+    pprint(header)
+    assert not(len(_lines_) != 1)         , "mutiple or no dataset selected : %i" % len (_lines_)
+    assert not(len(option) != len(header)), "header and options lentgh are different : (%i,%i)" % (len (option), len(header))
+    data_ = dict(zip(header, option))
+    data_['remote_dir'] = " ".join([data_['type'], data_['validity'], data_['ERA']])
+    print " ------------------------------"
+    pprint (data_)
+    print " ------------------------------"
+    return data_
+
+def json_select(JSON, run_range = "281693-282034", outdir=''):
+    range_ = [ int(run) for run in run_range.split("-")]
+    with open(JSON, 'r') as f:
+        idata = json.load(f)
+        odata = {}
+        for run, item in idata.items():
+            if int(run) >= range_[0] and int(run) <= range_[1]:
+                print run
+                odata[run] = item
+    outname = os.path.join(outdir, 'CRAB3-%s-JSON.txt' % run_range )
+    with open(outname, 'w') as f:
+        json.dump(odata, f, indent=4)
+    return outname
+
+def parse_crab_cfg(options, name):
+    crab_template = "python/crab_TEMPLATE.py"
+    pprint(options)
+    new_cfg = os.path.join(options['submission_dir'], os.path.basename( crab_template.replace('TEMPLATE', name)) )
+    with open(crab_template, "r") as inf, open(new_cfg, "w") as outf:
+        for line in inf:
+            line = line.replace('{DATASET}' , options['dataset'] )
+            if "{DATASET}"  in line : line = line.replace('{DATASET}' , options['dataset'   ] )
+            if "{TYPE}"     in line : line = line.replace('{TYPE}'    , options['type'      ] )
+            if "{GT}"       in line : line = line.replace('{GT}'      , options['GT'        ] )
+            if "{JSONFILE}" in line : line = line.replace('{JSONFILE}', options['json_file' ] )
+            if "{RUNRANGE}" in line : line = line.replace('{RUNRANGE}', options['run_range' ] )
+            if "{EOSDIR}"   in line : line = line.replace('{EOSDIR}'  , options['remote_dir'] )
+            if "{RUNONCAF}" in line : line = line.replace('{RUNONCAF}', options['run_on_caf'] )
+            outf.write(line)
+    print " ------------------------------"
+    print " --- crab file :: ", crab_template.replace('TEMPLATE', name)
+    os.system('cat ' + new_cfg )
+    print " ------------------------------"
+
+def get_options():
+    parser = OptionParser()
+    parser.add_option('-j','--json-file',
+                      dest='json_file',default='RUN2016H-281613-282037_13TeV_PromptReco_JSON_NoL1T.txt',
+                      help="""specify the JSON file""", metavar="FILE")
+
+    parser.add_option("-r", "--run-range",
+                      dest="run_range", default='281693-282034',
+                      help="""
+                      Specify the run range. This must be present in the input
+                      JSON file, and in the dataset file. The range shoud be
+                      specified for example as :
+                      --run-range "281613-282037"
+                      """)
+    parser.add_option("-n", "--name",
+                      dest="name", default='crab3-job-miniAOD',
+                      help="""
+                      name given to the job
+                      """)
+    parser.add_option('-q', '--run-on-caf',
+                      dest='run_on_caf',default=False,
+                      help="""
+                      Option allowing CRAB jobs to run on CAF queues:
+                      If you want to choose a specific site you can edit
+                      the generated crab config file
+                      """)
+    parser.add_option('-d','--dataset-file',
+                      dest='dataset_file',default='alcareco_datasets.dat',
+                      help="""
+                      dataset file containing the information about the run range:
+                      example :
+                      | run-range | dataset path | store path radical in eos | storing unit | ......
+                      281613-282037	/DoubleEG/Run2016H-PromptReco-v2/MINIAOD DoubleEG-Run2016H-noSkim-Prompt_v2-miniAOD caf database VALID RUN2016H
+                      """, metavar="FILE")
+    parser.add_option('-g','--global-tag',
+                      dest='global_tag',default='config/reRecoTags/80X_dataRun2_Prompt_v12.py',
+                      help="""
+                      Global Tag to the corresponding dataset :
+                      example :
+                      config/reRecoTags/80X_dataRun2_Prompt_v12.py
+                      """, metavar="FILE")
+    parser.add_option("-t", "--type",
+                      dest="type", default='MINIAODNTUPLE',
+                      help="""
+                      Type of the ntuple : MINIAODNTUPLE
+                      """)
+    parser.add_option('--create-only',
+                      dest="create_only", default=True,
+                      help="""This will crate JSON file and crab3 config file without submission""")
+    parser.add_option('--submit',
+                      dest="submit", default=True,
+                      help="""This will crate JSON file and crab3 config files and proceseed to submission:
+                      This command is equivalent of running : crab python/
+                      """)
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    (opt, args) =  get_options()
+
+    print " ------------------------------"
+    print " run-range  : ", opt.run_range
+    print " json-file  : ", opt.json_file
+    print " run on CAF : ", opt.run_on_caf
+    print " global tag : ", opt.global_tag
+    print " ------------------------------"
+    op = dataset_option("alcareco_datasets.dat",
+                        grep = [opt.run_range, opt.name],)
+    new_json = json_select(opt.json_file, opt.run_range)
+    op['GT'        ] = opt.global_tag
+    op['json_file' ] = new_json
+    op['type'      ] = opt.type
+    op['run_on_caf'] = opt.run_on_caf
+
+    options="-d ${DATASETPATH} -n ${DATASETNAME} -r ${RUNRANGE} --remote_dir ${ORIGIN_REMOTE_DIR_BASE}"
+    origin_remote_dir_base = "/store/group/dpg_ecal/alca_ecalcalib/ecalelf/ntuples/13TeV/"
+    remote_dir_base = ''
+    if "ALCARERECO" in op['type']:
+        print "running on ", op['type']
+        print "not implemented for now"
+    if "MINIAODNTUPLE" in op['type']:
+        print " ------------------------------"
+        op['remote_dir'] = '/'.join([
+            origin_remote_dir_base,
+            op['type'     ],
+            os.path.splitext(os.path.basename(op['GT']))[0],
+            op['eos'      ],
+            op['run_range']]
+        ) + '/'
+        print op['remote_dir']
+        print " ------------------------------"
+    op['submission_dir'] = 'crab-submit-%s-%s' % (op['ERA'], opt.run_range)
+    if not os.path.exists(op['submission_dir']):
+        os.makedirs(op['submission_dir'])
+    parse_crab_cfg(op , name='crab-%s-%s' % (opt.run_range, op['ERA']))
+    print " ------------------------------"
+    json_select   (new_json, run_range = opt.run_range, outdir= op['submission_dir'])
+    print " ------------------------------"

--- a/EcalAlCaRecoProducers/python/crab_TEMPLATE.py
+++ b/EcalAlCaRecoProducers/python/crab_TEMPLATE.py
@@ -1,0 +1,51 @@
+from CRABClient.UserUtilities import config
+import FWCore.ParameterSet.Config as cms
+
+config = config()
+
+config.General.requestName  = ''
+config.General.workArea     = 'crab_projects'
+config.General.transferLogs = True
+
+config.JobType.pluginName = 'Analysis'
+config.JobType.outputFiles= [
+    'ntuple.root'
+]
+config.JobType.psetName = 'python/alcaSkimming.py'
+config.JobType.pyCfgParams = [
+    'tagFile={GT}',
+    'type={TYPE}',
+    'doTreeOnly=1',
+    'doTree=1',
+    'jsonFile={JSONFILE}',
+    'isCrab=1',
+    'isPrivate=0',
+    'bunchSpacing=0']
+config.JobType.inputFiles = [
+    '{JSONFILE}'
+]
+
+config.JobType.allowUndistributedCMSSW = True
+config.JobType.maxJobRuntimeMin = 2750
+
+config.Data.inputDataset  = '{DATASET}'
+config.Data.inputDBS      = 'global'
+config.Data.splitting     = 'FileBased'#'LumiBased'
+config.Data.unitsPerJob   = 1 #30000
+config.Data.lumiMask      = '{JSONFILE}'
+config.Data.runRange      = '{RUNRANGE}'#'281613-282037'
+config.Data.outLFNDirBase = '{EOSDIR}'
+# file don't need to be published
+config.Data.publication   = False
+
+# GRID
+if {RUNONCAF}:
+    config.Site.whitelist = ['T3_CH_CERN_CAF']
+    config.Site.blacklist = ['T1_US_FNAL',
+                             'T2_UA_KIPT',
+                             'T2_UK_London_Brunel',
+                             'T2_CH_CSCS','T2_US_*']
+    config.Site.ignoreGlobalBlacklist = True
+else:
+    config.Site.storageSite   =  'T2_CH_CERN'
+

--- a/EcalAlCaRecoProducers/scripts/prod_ntuples.py
+++ b/EcalAlCaRecoProducers/scripts/prod_ntuples.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+from stability  import ParseTable as pt
+from shutil     import copyfile
+from optparse   import OptionParser
+from pprint     import pprint
+
+import os, re, sys, getopt
+
+def get_options():
+    parser = OptionParser()
+    parser.add_option("-r", "--run-range",
+                      dest="run_range", default='',
+                      help=" run ranges ")
+    parser.add_option("-d", "--datasetpath",
+                      dest="datasetpath", default='',
+                      help=" dataset path ")
+    parser.add_option("-n", "--datasetname",
+                      dest="datasetname", default='',
+                      help="dataset name")
+    parser.add_option("--store",
+                      dest="store", default='',
+                      help="storage directory")
+    parser.add_option("--remote_dir",
+                      dest="remote_dir", default='',
+                      help="remotre directory of the origin files")
+                    
+    
+    
+def 
+    

--- a/initCmsEnv.sh
+++ b/initCmsEnv.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-#source /afs/cern.ch/cms/LCG/LCG-2/UI/cms_ui_env.sh
-#eval `scramv1 runtime -sh`
-#source /afs/cern.ch/cms/ccs/wm/scripts/Crab/crab.sh
 source /cvmfs/cms.cern.ch/crab3/crab.sh
 case $USER in
     hengne|heli)
@@ -13,12 +10,11 @@ case $USER in
 	;;
 esac
 
-#cd calibration/SANDBOX
-#setenv PATH $PWD/bin:$PATH
-#PATH=`echo $PATH | sed 's|/afs/cern.ch/project/eos/installation/pro/bin/||'`
-
 PATH=$PATH:/afs/cern.ch/project/eos/installation/pro/bin/
 PATH=$PATH:$CMSSW_BASE/src/Calibration/EcalAlCaRecoProducers/bin
+
+echo "[CMSSW] " ${CMSSW_BASE}
+echo "[CRAB3] " $(which crab) 
 
 export ECALELFINIT=y
 


### PR DESCRIPTION
This is a preliminary tool for creating CRAB3 configuration for submission of ntuples production on the grid. For the moment the script create the JSON file for a selected run range from an original JSON file, and create a crab3 configuration file that can be submitted by `crab submit -c /path/to/cfg.py`. The run range and the corresponding dataset must be specified on `alcareco_dataset.dat`

cmd example ; `python prod_ntuples.py -j Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt -r "274198-275376" -q False --name 23Sep2016 -g config/reRecoTags/80X_dataRun2_2016SeptRepro_v4.py`

The full list of options of the `prod_ntuples.py` can be seen by typing : `python prod_ntuples.py --help`