### PR TITLE
Updating ECALELF to 92x

### DIFF
--- a/EOverPCalibration/interface/ConvoluteTemplate.h
+++ b/EOverPCalibration/interface/ConvoluteTemplate.h
@@ -1,7 +1,7 @@
 #ifndef ConvoluteTemplate_h
 #define ConvoluteTemplate_h
 
-#include "histoFunc.h"
+#include "Calibration/EOverPCalibration/interface/histoFunc.h"
 
 #include "TH1.h"
 #include "TF1.h"

--- a/EOverPCalibration/interface/FastCalibratorEB.h
+++ b/EOverPCalibration/interface/FastCalibratorEB.h
@@ -15,8 +15,8 @@
 #include <TH1F.h>
 #include <TProfile.h>
 #include <vector>
-#include "../interface/hChain.h"
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 #include <TGraphErrors.h>
 
 #include <TLorentzVector.h>
@@ -24,8 +24,8 @@
 //#include "Math/PtEtaPhiM4D.h"
 //#include "Math/LorentzVector.h"
 
-#include "../interface/CalibrationUtils.h"
-#include "../interface/readJSONFile.h"
+#include "Calibration/EOverPCalibration/interface/CalibrationUtils.h"
+#include "Calibration/EOverPCalibration/interface/readJSONFile.h"
 
 class FastCalibratorEB
 {

--- a/EOverPCalibration/interface/FastCalibratorEE.h
+++ b/EOverPCalibration/interface/FastCalibratorEE.h
@@ -15,8 +15,8 @@
 /* #include <TMath.h> */
 /* #include <TProfile.h> */
 /* #include <vector> */
-#include "../interface/hChain.h"
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 #include <TGraphErrors.h>
 
 /* #include <TLorentzVector.h> */
@@ -26,7 +26,7 @@
 
 /* #include "../interface/CalibrationUtils.h" */
 /* #include "../interface/readJSONFile.h" */
-#include "../interface/TEndcapRings.h"
+#include "Calibration/EOverPCalibration/interface/TEndcapRings.h"
 
 class FastCalibratorEE
 {

--- a/EOverPCalibration/interface/GetHashedIndexEB.h
+++ b/EOverPCalibration/interface/GetHashedIndexEB.h
@@ -4,8 +4,8 @@
 #include <TH1F.h>
 #include <TProfile.h>
 #include <vector>
-#include "../interface/hChain.h"
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 #include <TGraphErrors.h>
 
 #include <TLorentzVector.h>

--- a/EOverPCalibration/interface/GetHashedIndexEE.h
+++ b/EOverPCalibration/interface/GetHashedIndexEE.h
@@ -4,8 +4,8 @@
 #include <TH1F.h>
 #include <TProfile.h>
 #include <vector>
-#include "../interface/hChain.h"
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 #include <TGraphErrors.h>
 
 #include <TLorentzVector.h>

--- a/EOverPCalibration/interface/XtalAlphaEB.h
+++ b/EOverPCalibration/interface/XtalAlphaEB.h
@@ -14,14 +14,14 @@
 #include <TH1F.h>
 #include <TProfile.h>
 #include <vector>
-#include "../interface/hChain.h"
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 #include <TGraphErrors.h>
 
 #include <TLorentzVector.h>
 
-#include "../interface/CalibrationUtils.h"
-#include "../interface/readJSONFile.h"
+#include "Calibration/EOverPCalibration/interface/CalibrationUtils.h"
+#include "Calibration/EOverPCalibration/interface/readJSONFile.h"
 
 class XtalAlphaEB
 {

--- a/EOverPCalibration/interface/XtalAlphaEE.h
+++ b/EOverPCalibration/interface/XtalAlphaEE.h
@@ -14,15 +14,15 @@
 #include <TH1F.h>
 #include <TProfile.h>
 #include <vector>
-#include "../interface/hChain.h"
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 #include <TGraphErrors.h>
 
 
-#include "../interface/CalibrationUtils.h"
-#include "../interface/readJSONFile.h"
-#include "../interface/TEndcapRings.h"
-#include "../interface/TSicCrystals.h"
+#include "Calibration/EOverPCalibration/interface/CalibrationUtils.h"
+#include "Calibration/EOverPCalibration/interface/readJSONFile.h"
+#include "Calibration/EOverPCalibration/interface/TEndcapRings.h"
+#include "Calibration/EOverPCalibration/interface/TSicCrystals.h"
 
 class XtalAlphaEE
 {

--- a/EOverPCalibration/src/CalibrationUtils.cc
+++ b/EOverPCalibration/src/CalibrationUtils.cc
@@ -1,4 +1,4 @@
-#include "../interface/CalibrationUtils.h"
+#include "Calibration/EOverPCalibration/interface/CalibrationUtils.h"
 #include <fstream>
 #include <TF1.h>
 

--- a/EOverPCalibration/src/ConfigFileLine.cc
+++ b/EOverPCalibration/src/ConfigFileLine.cc
@@ -28,7 +28,7 @@
  * for it.
 */
 
-#include "../interface/ConfigFileLine.h"
+#include "Calibration/EOverPCalibration/interface/ConfigFileLine.h"
 #include <iostream>
 
 using namespace std;

--- a/EOverPCalibration/src/ConvoluteTemplate.cc
+++ b/EOverPCalibration/src/ConvoluteTemplate.cc
@@ -1,4 +1,4 @@
-#include "../interface/ConvoluteTemplate.h"
+#include "Calibration/EOverPCalibration/interface/ConvoluteTemplate.h"
 
 
 

--- a/EOverPCalibration/src/DrawingUtils.cc
+++ b/EOverPCalibration/src/DrawingUtils.cc
@@ -1,4 +1,4 @@
-#include "../interface/DrawingUtils.h"
+#include "Calibration/EOverPCalibration/interface/DrawingUtils.h"
 
 
 

--- a/EOverPCalibration/src/FastCalibratorEB.cc
+++ b/EOverPCalibration/src/FastCalibratorEB.cc
@@ -1,7 +1,7 @@
 //adapting it to ECALELF ntuple
 
-#include "../interface/FastCalibratorEB.h"
-#include "../interface/GetHashedIndexEB.h"
+#include "Calibration/EOverPCalibration/interface/FastCalibratorEB.h"
+#include "Calibration/EOverPCalibration/interface/GetHashedIndexEB.h"
 #include <TH2.h>
 #include <TF1.h>
 #include <TStyle.h>

--- a/EOverPCalibration/src/FastCalibratorEE.cc
+++ b/EOverPCalibration/src/FastCalibratorEE.cc
@@ -1,9 +1,9 @@
-#include "../interface/FastCalibratorEE.h"
-#include "../interface/GetHashedIndexEE.h"
+#include "Calibration/EOverPCalibration/interface/FastCalibratorEE.h"
+#include "Calibration/EOverPCalibration/interface/GetHashedIndexEE.h"
 #include <fstream>
 #include <TRandom3.h>
 #include <TString.h>
-#include "../interface/CalibrationUtils.h"
+#include "Calibration/EOverPCalibration/interface/CalibrationUtils.h"
 
 
 /// Default constructor

--- a/EOverPCalibration/src/GetHashedIndexEB.cc
+++ b/EOverPCalibration/src/GetHashedIndexEB.cc
@@ -1,4 +1,4 @@
-#include "../interface/GetHashedIndexEB.h"
+#include "Calibration/EOverPCalibration/interface/GetHashedIndexEB.h"
 
 int GetHashedIndexEB(int iEta, int iPhi, int Zside)
 {

--- a/EOverPCalibration/src/GetHashedIndexEE.cc
+++ b/EOverPCalibration/src/GetHashedIndexEE.cc
@@ -1,4 +1,4 @@
-#include "../interface/GetHashedIndexEE.h"
+#include "Calibration/EOverPCalibration/interface/GetHashedIndexEE.h"
 
 const int kxf[] =  {
 	41,  51,  41,  51,  41,  51,  36,  51,  36,  51,

--- a/EOverPCalibration/src/LHEReader.cc
+++ b/EOverPCalibration/src/LHEReader.cc
@@ -1,4 +1,4 @@
-#include "../interface/LHEReader.h"
+#include "Calibration/EOverPCalibration/interface/LHEReader.h"
 
 
 

--- a/EOverPCalibration/src/LaserMonitoringEoP.cc
+++ b/EOverPCalibration/src/LaserMonitoringEoP.cc
@@ -1,6 +1,6 @@
 //Class for the monitoring of laser corrections with E/p
 
-#include "../interface/LaserMonitoringEoP.h"
+#include "Calibration/EOverPCalibration/interface/LaserMonitoringEoP.h"
 #include <TH2.h>
 #include <TF1.h>
 #include <TStyle.h>

--- a/EOverPCalibration/src/TEndcapRings.cc
+++ b/EOverPCalibration/src/TEndcapRings.cc
@@ -1,4 +1,4 @@
-#include "../interface/TEndcapRings.h"
+#include "Calibration/EOverPCalibration/interface/TEndcapRings.h"
 
 
 

--- a/EOverPCalibration/src/TSicCrystals.cc
+++ b/EOverPCalibration/src/TSicCrystals.cc
@@ -1,4 +1,4 @@
-#include "../interface/TSicCrystals.h"
+#include "Calibration/EOverPCalibration/interface/TSicCrystals.h"
 
 // default constructor, reading the map from file
 TSicCrystals::TSicCrystals()

--- a/EOverPCalibration/src/XtalAlphaEB.cc
+++ b/EOverPCalibration/src/XtalAlphaEB.cc
@@ -1,5 +1,5 @@
-#include "../interface/XtalAlphaEB.h"
-#include "../interface/GetHashedIndexEB.h"
+#include "Calibration/EOverPCalibration/interface/XtalAlphaEB.h"
+#include "Calibration/EOverPCalibration/interface/GetHashedIndexEB.h"
 #include <TH2.h>
 #include <TF1.h>
 #include <TStyle.h>

--- a/EOverPCalibration/src/XtalAlphaEE.cc
+++ b/EOverPCalibration/src/XtalAlphaEE.cc
@@ -1,5 +1,5 @@
-#include "../interface/XtalAlphaEE.h"
-#include "../interface/GetHashedIndexEE.h"
+#include "Calibration/EOverPCalibration/interface/XtalAlphaEE.h"
+#include "Calibration/EOverPCalibration/interface/GetHashedIndexEE.h"
 #include <TH2.h>
 #include <TF1.h>
 #include <TStyle.h>

--- a/EOverPCalibration/src/Zutils.cc
+++ b/EOverPCalibration/src/Zutils.cc
@@ -1,4 +1,4 @@
-#include "../interface/Zutils.h"
+#include "Calibration/EOverPCalibration/interface/Zutils.h"
 #include <cmath>
 #include "TMath.h"
 #include "TRandom3.h"

--- a/EOverPCalibration/src/geometryUtils.cc
+++ b/EOverPCalibration/src/geometryUtils.cc
@@ -1,4 +1,4 @@
-#include "../interface/geometryUtils.h"
+#include "Calibration/EOverPCalibration/interface/geometryUtils.h"
 
 // --- EE ---
 // default constructor, reading the map from file

--- a/EOverPCalibration/src/h2Chain.cc
+++ b/EOverPCalibration/src/h2Chain.cc
@@ -1,4 +1,4 @@
-#include "../interface/h2Chain.h"
+#include "Calibration/EOverPCalibration/interface/h2Chain.h"
 
 h2Chain::h2Chain (TString baseName, TString baseTitle,
                   int nbinsx, double minx, double maxx,

--- a/EOverPCalibration/src/hChain.cc
+++ b/EOverPCalibration/src/hChain.cc
@@ -1,4 +1,4 @@
-#include "../interface/hChain.h"
+#include "Calibration/EOverPCalibration/interface/hChain.h"
 #include "TStyle.h"
 #include "TROOT.h"
 #include "TCanvas.h"

--- a/EOverPCalibration/src/ntpleUtils.cc
+++ b/EOverPCalibration/src/ntpleUtils.cc
@@ -1,4 +1,4 @@
-#include "../interface/ntpleUtils.h"
+#include "Calibration/EOverPCalibration/interface/ntpleUtils.h"
 
 
 //  ------------------------------------------------------------

--- a/EOverPCalibration/src/ntpleUtils2.cc
+++ b/EOverPCalibration/src/ntpleUtils2.cc
@@ -1,4 +1,4 @@
-#include "../interface/ntpleUtils2.h"
+#include "Calibration/EOverPCalibration/interface/ntpleUtils2.h"
 
 TH1F* templateHisto;
 TF1* templateFunc;

--- a/EOverPCalibration/src/readJSONFile.cc
+++ b/EOverPCalibration/src/readJSONFile.cc
@@ -1,4 +1,4 @@
-#include "../interface/readJSONFile.h"
+#include "Calibration/EOverPCalibration/interface/readJSONFile.h"
 
 
 

--- a/EOverPCalibration/src/stabilityUtils.cc
+++ b/EOverPCalibration/src/stabilityUtils.cc
@@ -1,4 +1,4 @@
-#include "../interface/stabilityUtils.h"
+#include "Calibration/EOverPCalibration/interface/stabilityUtils.h"
 
 using namespace std;
 

--- a/EOverPCalibration/src/treeReader.cc
+++ b/EOverPCalibration/src/treeReader.cc
@@ -1,4 +1,4 @@
-#include "../interface/treeReader.h"
+#include "Calibration/EOverPCalibration/interface/treeReader.h"
 
 treeReader::treeReader (TTree * tree, bool verbosity) :
 	m_tree (tree),

--- a/EcalAlCaRecoProducers/plugins/AlCaECALRecHitReducer.cc
+++ b/EcalAlCaRecoProducers/plugins/AlCaECALRecHitReducer.cc
@@ -32,7 +32,7 @@ AlCaECALRecHitReducer::AlCaECALRecHitReducer(const edm::ParameterSet& iConfig)
 
 	std::vector<edm::InputTag> srcLabels = iConfig.getParameter< std::vector<edm::InputTag> >("srcLabels");
 	for ( auto inputTag = srcLabels.begin(); inputTag != srcLabels.end(); ++inputTag) {
-		eleViewTokens_.push_back(consumes<edm::View <reco::RecoCandidate> >(*inputTag));
+	  eleViewTokens_.push_back(consumes<edm::View <reco::RecoCandidate> >(*inputTag));
 	}
 
 	//eleViewToken_ = consumes<edm::View <reco::RecoCandidate> > (iConfig.getParameter< edm::InputTag > ("electronLabel"));
@@ -130,11 +130,11 @@ AlCaECALRecHitReducer::produce (edm::Event& iEvent,
 	iEvent.getByToken(EESuperClusterToken_, EESCHandle);
 
 	//Create empty output collections
-	std::auto_ptr< EBRecHitCollection > miniEBRecHitCollection (new EBRecHitCollection) ;
-	std::auto_ptr< EERecHitCollection > miniEERecHitCollection (new EERecHitCollection) ;
-	std::auto_ptr< ESRecHitCollection > miniESRecHitCollection (new ESRecHitCollection) ;
-	std::auto_ptr< EBUncalibratedRecHitCollection > miniEBUncalibRecHitCollection (new EBUncalibratedRecHitCollection) ;
-	std::auto_ptr< EEUncalibratedRecHitCollection > miniEEUncalibRecHitCollection (new EEUncalibratedRecHitCollection) ;
+	std::unique_ptr< EBRecHitCollection > miniEBRecHitCollection (new EBRecHitCollection) ;
+	std::unique_ptr< EERecHitCollection > miniEERecHitCollection (new EERecHitCollection) ;
+	std::unique_ptr< ESRecHitCollection > miniESRecHitCollection (new ESRecHitCollection) ;
+	std::unique_ptr< EBUncalibratedRecHitCollection > miniEBUncalibRecHitCollection (new EBUncalibratedRecHitCollection) ;
+	std::unique_ptr< EEUncalibratedRecHitCollection > miniEEUncalibRecHitCollection (new EEUncalibratedRecHitCollection) ;
 
 	std::set<DetId> reducedRecHit_EBmap;
 	std::set<DetId> reducedRecHit_EEmap;
@@ -142,7 +142,7 @@ AlCaECALRecHitReducer::produce (edm::Event& iEvent,
 
 	//  std::set< edm::Ref<reco::CaloCluster> > reducedCaloClusters_map;
 
-	std::auto_ptr< reco::CaloClusterCollection > reducedCaloClusterCollection (new reco::CaloClusterCollection);
+	std::unique_ptr< reco::CaloClusterCollection > reducedCaloClusterCollection (new reco::CaloClusterCollection);
 
 	//Photons:
 #ifdef shervin
@@ -166,11 +166,11 @@ AlCaECALRecHitReducer::produce (edm::Event& iEvent,
 #endif
 
 	Handle<edm::View < reco::RecoCandidate> > eleViewHandle;
-	for(auto iToken = eleViewTokens_.begin(); iToken != eleViewTokens_.end(); iToken++) {
+	for( auto iToken = eleViewTokens_.begin(); iToken != eleViewTokens_.end(); iToken++) {
 		iEvent.getByToken(*iToken, eleViewHandle);
 
 		//Electrons:
-		for (auto eleIt = eleViewHandle->begin(); eleIt != eleViewHandle->end(); eleIt++) {
+		for ( auto eleIt = eleViewHandle->begin(); eleIt != eleViewHandle->end(); eleIt++) {
 			const reco::SuperCluster& sc = *(eleIt->superCluster()) ;
 
 			if (sc.seed()->seed().subdetId() == EcalBarrel) {
@@ -238,13 +238,12 @@ AlCaECALRecHitReducer::produce (edm::Event& iEvent,
 	}
 
 	//--------------------------------------- Put selected information in the event
-	iEvent.put( miniEBRecHitCollection, alcaBarrelHitsCollection_ );
-	iEvent.put( miniEBUncalibRecHitCollection, alcaBarrelUncalibHitsCollection_ );
-	iEvent.put( miniEERecHitCollection, alcaEndcapHitsCollection_ );
-	iEvent.put( miniEEUncalibRecHitCollection, alcaEndcapUncalibHitsCollection_ );
-	iEvent.put( miniESRecHitCollection, alcaPreshowerHitsCollection_ );
-
-	iEvent.put( reducedCaloClusterCollection, alcaCaloClusterCollection_);
+	iEvent.put( std::move( miniEBRecHitCollection ), alcaBarrelHitsCollection_ );
+	iEvent.put( std::move( miniEBUncalibRecHitCollection ), alcaBarrelUncalibHitsCollection_ );
+	iEvent.put( std::move( miniEERecHitCollection ), alcaEndcapHitsCollection_ );
+	iEvent.put( std::move( miniEEUncalibRecHitCollection ), alcaEndcapUncalibHitsCollection_ );
+	iEvent.put( std::move( miniESRecHitCollection ), alcaPreshowerHitsCollection_ );
+	iEvent.put( std::move( reducedCaloClusterCollection ), alcaCaloClusterCollection_);
 }
 
 void AlCaECALRecHitReducer::AddMiniRecHitCollection(const reco::SuperCluster& sc,
@@ -273,7 +272,7 @@ void AlCaECALRecHitReducer::AddMiniRecHitCollection(const reco::SuperCluster& sc
 
 	if (sc.preshowerClusters().isAvailable()) {
 //		std::cout << "[DEBUG] Preshower available!" << std::endl;
-		for(auto iES = sc.preshowerClustersBegin(); iES != sc.preshowerClustersEnd(); ++iES) {
+	  for( auto iES = sc.preshowerClustersBegin(); iES != sc.preshowerClustersEnd(); ++iES) {
 			const std::vector< std::pair<DetId, float> >& hits = (*iES)->hitsAndFractions();
 			for(std::vector<std::pair<DetId, float> >::const_iterator rh = hits.begin(); rh != hits.end(); ++rh) {
 				reducedESRecHitMap.insert(rh->first);

--- a/EcalAlCaRecoProducers/plugins/AlCaElectronTracksReducer.cc
+++ b/EcalAlCaRecoProducers/plugins/AlCaElectronTracksReducer.cc
@@ -44,8 +44,8 @@ void AlCaElectronTracksReducer::produce (edm::Event& iEvent,
 	iEvent.getByToken(generalTracksExtraToken_, generalTracksExtraHandle);
 
 	//Create empty output collections
-	std::auto_ptr< TrackCollection > redGeneralTracksCollection (new TrackCollection) ;
-	std::auto_ptr< TrackExtraCollection > redGeneralTracksExtraCollection (new TrackExtraCollection) ;
+	std::unique_ptr< TrackCollection > redGeneralTracksCollection (new TrackCollection) ;
+	std::unique_ptr< TrackExtraCollection > redGeneralTracksExtraCollection (new TrackExtraCollection) ;
 
 	reco::GsfElectronCollection::const_iterator eleIt;
 

--- a/EcalAlCaRecoProducers/plugins/AlCaElectronTracksReducer.cc
+++ b/EcalAlCaRecoProducers/plugins/AlCaElectronTracksReducer.cc
@@ -65,8 +65,8 @@ void AlCaElectronTracksReducer::produce (edm::Event& iEvent,
 	}
 
 	//Put selected information in the event
-	iEvent.put( redGeneralTracksCollection, alcaTrackCollection_ );
-	iEvent.put( redGeneralTracksExtraCollection, alcaTrackExtraCollection_ );
+	iEvent.put( std::move(redGeneralTracksCollection), alcaTrackCollection_ );
+	iEvent.put( std::move(redGeneralTracksExtraCollection), alcaTrackExtraCollection_ );
 }
 
 

--- a/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
+++ b/EcalAlCaRecoProducers/plugins/SelectedElectronFEDListProducer.cc
@@ -567,7 +567,7 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event & iEvent, 
 	}
 
 	// make the final raw data collection
-	std::auto_ptr<FEDRawDataCollection> streamFEDRawProduct(new FEDRawDataCollection());
+	std::unique_ptr<FEDRawDataCollection> streamFEDRawProduct(new FEDRawDataCollection());
 	std::sort(fedList_.begin(), fedList_.end());
 	std::vector<uint32_t>::const_iterator itfedList = fedList_.begin();
 	for( ; itfedList != fedList_.end() ; ++itfedList) {
@@ -580,7 +580,7 @@ void SelectedElectronFEDListProducer<TEle, TCand>::produce(edm::Event & iEvent, 
 		}
 	}
 
-	iEvent.put(streamFEDRawProduct, outputLabelModule_);
+	iEvent.put(std::move( streamFEDRawProduct ), outputLabelModule_);
 
 	if(!fedList_.empty())   fedList_.clear();
 

--- a/EcalAlCaRecoProducers/src/ElectronRecalibSuperClusterAssociatorSH.cc_topatch
+++ b/EcalAlCaRecoProducers/src/ElectronRecalibSuperClusterAssociatorSH.cc_topatch
@@ -56,8 +56,8 @@ void ElectronRecalibSuperClusterAssociatorSH::produce(edm::Event& e, const edm::
   std::cout<< "ElectronRecalibSuperClusterAssociatorSH::produce" << std::endl;
 #endif
   // Create the output collections   
-  std::auto_ptr<GsfElectronCollection> pOutEle(new GsfElectronCollection);
-  std::auto_ptr<GsfElectronCoreCollection> pOutEleCore(new GsfElectronCoreCollection);
+  std::unique_ptr<GsfElectronCollection> pOutEle(new GsfElectronCollection);
+  std::unique_ptr<GsfElectronCoreCollection> pOutEleCore(new GsfElectronCoreCollection);
   //  std::auto_ptr<SuperClusterCollection> pOutNewEndcapSC(new SuperClusterCollection);
 
 //   reco::SuperClusterRefProd rSC = e.getRefBeforePut<SuperClusterCollection>();

--- a/EcalAlCaRecoProducers/src/ValueMapTraslator.cc
+++ b/EcalAlCaRecoProducers/src/ValueMapTraslator.cc
@@ -117,7 +117,7 @@ ValueMapTraslator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 	using namespace edm;
 	std::vector<value_t>  valueVector;
-	std::auto_ptr<Map_t> valueVectorPtr(new Map_t());
+	std::unique_ptr<Map_t> valueVectorPtr(new Map_t());
 
 	//------------------------------
 	Handle< reco::GsfElectronCollection > referenceHandle;
@@ -174,7 +174,7 @@ ValueMapTraslator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	filler.insert(referenceHandle, valueVector.begin(), valueVector.end());
 	filler.fill();
 
-	iEvent.put(valueVectorPtr);
+	iEvent.put(std::move(valueVectorPtr));
 
 }
 

--- a/EcalCalibAlgos/interface/ZeeCalibration.h
+++ b/EcalCalibAlgos/interface/ZeeCalibration.h
@@ -99,7 +99,7 @@ public:
 	virtual Status duringLoop( const edm::Event&, const edm::EventSetup& );
 
 	/// Produce Ecal interCalibrations
-	virtual boost::shared_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& );
+	virtual std::shared_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& );
 
 private:
 
@@ -200,7 +200,7 @@ private:
 	float calibCoeffError[nMaxChannels];
 	float initCalibCoeff[nMaxChannels];
 
-	boost::shared_ptr<EcalIntercalibConstants> ical;
+	std::shared_ptr<EcalIntercalibConstants> ical;
 
 	ZIterativeAlgorithmWithFit* theAlgorithm_;
 

--- a/EcalCalibAlgos/interface/ZeeCalibration.h
+++ b/EcalCalibAlgos/interface/ZeeCalibration.h
@@ -75,19 +75,19 @@ class ZeeCalibration : public edm::ESProducerLooper
 public:
 
 	/// Constructor
-	ZeeCalibration( const edm::ParameterSet& iConfig );
+	ZeeCalibration( const edm::ParameterSet& );
 
 	/// Destructor
-	~ZeeCalibration();
+	~ZeeCalibration() = default;
 
 	/// Dummy implementation (job done in duringLoop)
 	virtual void produce(edm::Event&, const edm::EventSetup&) {};
 
 	/// Called at beginning of job
-	virtual void beginOfJob();
+	virtual void beginOfJob() override;
 
 	/// Called at end of job
-	virtual void endOfJob();
+	virtual void endOfJob() override;
 
 	/// Called at beginning of loop
 	virtual void startingNewLoop( unsigned int iLoop );
@@ -99,7 +99,7 @@ public:
 	virtual Status duringLoop( const edm::Event&, const edm::EventSetup& );
 
 	/// Produce Ecal interCalibrations
-	virtual boost::shared_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& iRecord );
+	virtual boost::shared_ptr<EcalIntercalibConstants> produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& );
 
 private:
 
@@ -114,11 +114,16 @@ private:
 	int ringNumberCorrector(int k);
 	double getEtaCorrection(const reco::GsfElectron*);
 
-	\
-	void fillEleInfo(std::vector<HepMC::GenParticle*>& a, std::map<HepMC::GenParticle*, const reco::GsfElectron*>& b);
-	void fillMCInfo(HepMC::GenParticle* mcele);
+	
+	void fillEleInfo(std::vector<HepMC::GenParticle*>&,
+			 std::map<HepMC::GenParticle*,
+			 const reco::GsfElectron*>&);
+	void fillMCInfo(HepMC::GenParticle*);
 
-	void fillMCmap(const std::vector<const reco::GsfElectron*>* electronCollection, const std::vector<HepMC::GenParticle*>& mcEle, std::map<HepMC::GenParticle*, const reco::GsfElectron*>& myMCmap);
+	void fillMCmap(const std::vector<const reco::GsfElectron*>*,
+		       const std::vector<HepMC::GenParticle*>&,
+		       std::map<HepMC::GenParticle*,
+		       const reco::GsfElectron*>&);
 	//  void fillMCmap(const reco::ElectronCollection* electronCollection, const std::vector<HepMC::GenParticle*>& mcEle,std::map<HepMC::GenParticle*,const reco::Electron*>& myMCmap);
 
 	float EvalDPhi(float Phi, float Phi_ref);
@@ -133,7 +138,9 @@ private:
 
 	void printStatistics();
 
-	std::pair<DetId, double> getHottestDetId(const std::vector<std::pair<DetId, float> >& mySCRecHits, const EBRecHitCollection* ebhits , const EERecHitCollection* eehits);
+	std::pair<DetId, double> getHottestDetId(const std::vector<std::pair<DetId, float> >&,
+						 const EBRecHitCollection*,
+						 const EERecHitCollection*);
 
 	bool xtalIsOnModuleBorder( EBDetId myEBDetId );
 

--- a/EcalCalibAlgos/src/ElectronRecalibSuperClusterAssociator.cc
+++ b/EcalCalibAlgos/src/ElectronRecalibSuperClusterAssociator.cc
@@ -55,8 +55,8 @@ void ElectronRecalibSuperClusterAssociator::produce(edm::Event& e, const edm::Ev
 	iSetup.get<CaloGeometryRecord>().get(_theGeometry);
 
 	// Create the output collections
-	std::auto_ptr<reco::GsfElectronCollection> pOutEle(new reco::GsfElectronCollection);
-	std::auto_ptr<reco::GsfElectronCoreCollection> pOutEleCore(new reco::GsfElectronCoreCollection);
+	std::unique_ptr<reco::GsfElectronCollection> pOutEle(new reco::GsfElectronCollection);
+	std::unique_ptr<reco::GsfElectronCoreCollection> pOutEleCore(new reco::GsfElectronCoreCollection);
 
 	// Get SuperClusters in EB
 	edm::Handle<reco::SuperClusterCollection> superClusterEBHandle;
@@ -208,8 +208,8 @@ void ElectronRecalibSuperClusterAssociator::produce(edm::Event& e, const edm::Ev
 
 	// put result into the Event
 
-	e.put(pOutEle);
-	e.put(pOutEleCore);
+	e.put(std::move( pOutEle ));
+	e.put(std::move( pOutEleCore ));
 
 	//  e.put(pOutNewEndcapSC);
 

--- a/EcalCalibAlgos/src/ZeeCalibration.cc
+++ b/EcalCalibAlgos/src/ZeeCalibration.cc
@@ -172,15 +172,15 @@ ZeeCalibration::ZeeCalibration(const edm::ParameterSet& iConfig)
 }
 
 
-ZeeCalibration::~ZeeCalibration()
-{
-//   if (theAlgorithm_)
-//     delete theAlgorithm_;
-}
+//ZeeCalibration::~ZeeCalibration()
+//{
+////   if (theAlgorithm_)
+////     delete theAlgorithm_;
+//}
 
 //_____________________________________________________________________________
 // Produce EcalIntercalibConstants
-boost::shared_ptr<EcalIntercalibConstants>
+std::shared_ptr<EcalIntercalibConstants>
 ZeeCalibration::produceEcalIntercalibConstants( const EcalIntercalibConstantsRcd& iRecord )
 {
 	std::cout << "@SUB=ZeeCalibration::produceEcalIntercalibConstants" << std::endl;
@@ -737,7 +737,9 @@ ZeeCalibration::duringLoop( const edm::Event& iEvent, const edm::EventSetup& iSe
 			}
 		}
 
-		ical = boost::shared_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+		//ical = boost::shared_ptr<EcalIntercalibConstants>( new EcalIntercalibConstants() );
+		ical = std::make_shared<EcalIntercalibConstants>();
+		//ical = std::make_unique<EcalIntercalibConstants>();
 
 		for(int k = 0; k < theAlgorithm_->getNumberOfChannels(); k++) {
 			//      std::vector<DetId> ringIds = EcalRingCalibrationTools::getDetIdsInRing(k);

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Download instructions.
 ```
 wget --no-check-certificate https://raw.githubusercontent.com/ECALELFS/ECALELF/HEAD/setup_git.sh
 chmod +x setup_git.sh
-CMSSW_VERSION=CMSSW_8_0_24_patch1
+CMSSW_VERSION=CMSSW_9_2_0_patch5
 ./setup_git.sh $CMSSW_VERSION
 cd $CMSSW_VERSION/src/
 cmsenv

--- a/ZFitter/src/anyVar_class.cc
+++ b/ZFitter/src/anyVar_class.cc
@@ -9,15 +9,15 @@
 #define MAXBRANCHES  20
 #define BUFSIZE 12 /* bytes */
 #include <cassert>
-
+#include <iomanip>
 
 anyVar_class::~anyVar_class(void)
 {
 	std::cerr << "[anyVar_class DESTROYING]" << std::endl;
-//	data_chain->SetEntryList(NULL);
-//	reduced_data_vec.clear();
+	//	data_chain->SetEntryList(NULL);
+	//	reduced_data_vec.clear();
 	std::cerr << "[anyVar_class DESTROY]" << std::endl;
-//	delete data_chain;
+	//	delete data_chain;
 }
 
 anyVar_class::anyVar_class(TChain *data_chain_, std::vector<std::string> branchNames, ElectronCategory_class& cutter, std::string massBranchName, std::string outDirFitRes, TDirectory* dir, bool updateOnly):

--- a/ZNtupleDumper/plugins/EleNewEnergiesProducer.cc
+++ b/ZNtupleDumper/plugins/EleNewEnergiesProducer.cc
@@ -196,12 +196,12 @@ void
 EleNewEnergiesProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
 	using namespace edm;
+	
 
-
-	std::auto_ptr<NewEnergyMap> energySC_mustMap(new NewEnergyMap());
-	std::auto_ptr<NewEnergyMap> energySC_mustVarMap(new NewEnergyMap());
-	std::auto_ptr<NewEnergyMap> energySC_phoMap(new NewEnergyMap());
-	std::auto_ptr<NewEnergyMap> energySC_phoVarMap(new NewEnergyMap());
+	std::unique_ptr<NewEnergyMap> energySC_mustMap(new NewEnergyMap());
+	std::unique_ptr<NewEnergyMap> energySC_mustVarMap(new NewEnergyMap());
+	std::unique_ptr<NewEnergyMap> energySC_phoMap(new NewEnergyMap());
+	std::unique_ptr<NewEnergyMap> energySC_phoVarMap(new NewEnergyMap());
 
 	iEvent.getByToken(electronsTAG, electronsHandle);
 	iEvent.getByToken(photonsTAG, photonsHandle);
@@ -271,10 +271,10 @@ EleNewEnergiesProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 
 	//------------------------------
 	// put the ValueMap in the event
-	iEvent.put(energySC_mustMap, "energySCEleMust");
-	iEvent.put(energySC_mustVarMap, "energySCEleMustVar");
-	iEvent.put(energySC_phoMap, "energySCElePho");
-	iEvent.put(energySC_phoVarMap, "energySCElePhoVar");
+	iEvent.put(std::move(energySC_mustMap), "energySCEleMust");
+	iEvent.put(std::move(energySC_mustVarMap), "energySCEleMustVar");
+	iEvent.put(std::move(energySC_phoMap), "energySCElePho");
+	iEvent.put(std::move(energySC_phoVarMap), "energySCElePhoVar");
 
 }
 

--- a/ZNtupleDumper/plugins/EleSelectionProducers.cc
+++ b/ZNtupleDumper/plugins/EleSelectionProducers.cc
@@ -56,9 +56,9 @@ class EleSelectionProducers : public edm::EDProducer
 
 public:
 	explicit EleSelectionProducers(const edm::ParameterSet&);
-	~EleSelectionProducers();
+        ~EleSelectionProducers() = default;
 
-	static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+	static void fillDescriptions(edm::ConfigurationDescriptions&);
 
 private:
 	virtual void beginJob() ;
@@ -183,13 +183,13 @@ EleSelectionProducers::EleSelectionProducers(const edm::ParameterSet& iConfig):
 }
 
 
-EleSelectionProducers::~EleSelectionProducers()
-{
+//EleSelectionProducers::~EleSelectionProducers()
+//{
 
 	// do anything here that needs to be done at desctruction time
 	// (e.g. close files, deallocate resources etc.)
 
-}
+//}
 
 
 //
@@ -205,34 +205,34 @@ void EleSelectionProducers::produce(edm::Event& iEvent, const edm::EventSetup& i
 	std::vector<SelectionValue_t>  WP70_PU_vec;
 	std::vector<SelectionValue_t>  WP80_PU_vec;
 	std::vector<SelectionValue_t>  WP90_PU_vec;
-	std::auto_ptr<SelectionMap> fiducialMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> WP70_PUMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> WP80_PUMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> WP90_PUMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> fiducialMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> WP70_PUMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> WP80_PUMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> WP90_PUMap(new SelectionMap());
 	std::vector<SelectionValue_t>  loose_vec;
 	std::vector<SelectionValue_t>  medium_vec;
 	std::vector<SelectionValue_t>  tight_vec;
-	std::auto_ptr<SelectionMap> looseMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> mediumMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> tightMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> looseMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> mediumMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> tightMap(new SelectionMap());
 	std::vector<SelectionValue_t>  loose25nsRun2_vec;
 	std::vector<SelectionValue_t>  medium25nsRun2_vec;
 	std::vector<SelectionValue_t>  tight25nsRun2_vec;
-	std::auto_ptr<SelectionMap> looseMap_run2_25ns(new SelectionMap());
-	std::auto_ptr<SelectionMap> mediumMap_run2_25ns(new SelectionMap());
-	std::auto_ptr<SelectionMap> tightMap_run2_25ns(new SelectionMap());
+	std::unique_ptr<SelectionMap> looseMap_run2_25ns(new SelectionMap());
+	std::unique_ptr<SelectionMap> mediumMap_run2_25ns(new SelectionMap());
+	std::unique_ptr<SelectionMap> tightMap_run2_25ns(new SelectionMap());
 	std::vector<SelectionValue_t>  loose50nsRun2_vec;
 	std::vector<SelectionValue_t>  medium50nsRun2_vec;
 	std::vector<SelectionValue_t>  tight50nsRun2_vec;
-	std::auto_ptr<SelectionMap> looseMap50nsRun2(new SelectionMap());
-	std::auto_ptr<SelectionMap> mediumMap50nsRun2(new SelectionMap());
-	std::auto_ptr<SelectionMap> tightMap50nsRun2(new SelectionMap());
+	std::unique_ptr<SelectionMap> looseMap50nsRun2(new SelectionMap());
+	std::unique_ptr<SelectionMap> mediumMap50nsRun2(new SelectionMap());
+	std::unique_ptr<SelectionMap> tightMap50nsRun2(new SelectionMap());
 
 	std::vector<SelectionValue_t>  medium25nsRun2Boff_vec;
-	std::auto_ptr<SelectionMap> mediumMap25nsRun2Boff(new SelectionMap());
+	std::unique_ptr<SelectionMap> mediumMap25nsRun2Boff(new SelectionMap());
 
 	std::vector<SelectionValue_t>  loose25nsRun2V2016_vec;
-	std::auto_ptr<SelectionMap> looseMap_run2_25nsV2016(new SelectionMap());
+	std::unique_ptr<SelectionMap> looseMap_run2_25nsV2016(new SelectionMap());
 
 	//------------------------------ ELECTRON
 	iEvent.getByToken(electronsToken_, electronsHandle);
@@ -437,21 +437,21 @@ void EleSelectionProducers::produce(edm::Event& iEvent, const edm::EventSetup& i
 
 	//------------------------------
 	// put the ValueMap in the event
-	iEvent.put(fiducialMap, "fiducial");
-	iEvent.put(WP70_PUMap, "WP70PU");
-	iEvent.put(WP80_PUMap, "WP80PU");
-	iEvent.put(WP90_PUMap, "WP90PU");
-	iEvent.put(looseMap, "loose");
-	iEvent.put(mediumMap, "medium");
-	iEvent.put(tightMap, "tight");
-	iEvent.put(looseMap_run2_25ns, "loose25nsRun2");
-	iEvent.put(mediumMap_run2_25ns, "medium25nsRun2");
-	iEvent.put(tightMap_run2_25ns, "tight25nsRun2");
-	iEvent.put(looseMap50nsRun2, "loose50nsRun2");
-	iEvent.put(mediumMap50nsRun2, "medium50nsRun2");
-	iEvent.put(tightMap50nsRun2, "tight50nsRun2");
-	iEvent.put(mediumMap25nsRun2Boff, "medium25nsRun2Boff");
-	iEvent.put(looseMap_run2_25nsV2016, "loose25nsRun2V2016");
+	iEvent.put(std::move(fiducialMap), "fiducial");
+	iEvent.put(std::move(WP70_PUMap), "WP70PU");
+	iEvent.put(std::move(WP80_PUMap), "WP80PU");
+	iEvent.put(std::move(WP90_PUMap), "WP90PU");
+	iEvent.put(std::move(looseMap), "loose");
+	iEvent.put(std::move(mediumMap), "medium");
+	iEvent.put(std::move(tightMap), "tight");
+	iEvent.put(std::move(looseMap_run2_25ns), "loose25nsRun2");
+	iEvent.put(std::move(mediumMap_run2_25ns), "medium25nsRun2");
+	iEvent.put(std::move(tightMap_run2_25ns), "tight25nsRun2");
+	iEvent.put(std::move(looseMap50nsRun2), "loose50nsRun2");
+	iEvent.put(std::move(mediumMap50nsRun2), "medium50nsRun2");
+	iEvent.put(std::move(tightMap50nsRun2), "tight50nsRun2");
+	iEvent.put(std::move(mediumMap25nsRun2Boff), "medium25nsRun2Boff");
+	iEvent.put(std::move(looseMap_run2_25nsV2016), "loose25nsRun2V2016");
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/ZNtupleDumper/plugins/MuonSelectionProducers.cc
+++ b/ZNtupleDumper/plugins/MuonSelectionProducers.cc
@@ -154,15 +154,15 @@ void MuonSelectionProducers::produce(edm::Event& iEvent, const edm::EventSetup& 
 	using namespace edm;
 
 	std::vector<SelectionValue_t>  fiducial_vec;
-	std::auto_ptr<SelectionMap> fiducialMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> fiducialMap(new SelectionMap());
 	std::vector<SelectionValue_t>  loose_vec;
 	std::vector<SelectionValue_t>  soft_vec;
 	std::vector<SelectionValue_t>  tight_vec;
 	std::vector<SelectionValue_t>  highPT_vec;
-	std::auto_ptr<SelectionMap> looseMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> softMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> tightMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> highPTMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> looseMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> softMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> tightMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> highPTMap(new SelectionMap());
 
 	//------------------------------ MUON
 	iEvent.getByLabel(muonsTAG, muonsHandle);
@@ -256,11 +256,11 @@ void MuonSelectionProducers::produce(edm::Event& iEvent, const edm::EventSetup& 
 
 	//------------------------------
 	// put the ValueMap in the event
-	iEvent.put(fiducialMap, "fiducial");
-	iEvent.put(looseMap, "loose");
-	iEvent.put(softMap, "soft");
-	iEvent.put(tightMap, "tight");
-	iEvent.put(highPTMap, "highPT");
+	iEvent.put(std::move(fiducialMap), "fiducial");
+	iEvent.put(std::move(looseMap), "loose");
+	iEvent.put(std::move(softMap), "soft");
+	iEvent.put(std::move(tightMap), "tight");
+	iEvent.put(std::move(highPTMap), "highPT");
 
 }
 

--- a/ZNtupleDumper/plugins/PhoSelectionProducers.cc
+++ b/ZNtupleDumper/plugins/PhoSelectionProducers.cc
@@ -162,19 +162,19 @@ void PhoSelectionProducers::produce(edm::Event& iEvent, const edm::EventSetup& i
 	using namespace edm;
 
 	std::vector<SelectionValue_t>  fiducial_vec;
-	std::auto_ptr<SelectionMap> fiducialMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> fiducialMap(new SelectionMap());
 	std::vector<SelectionValue_t>  loose_vec;
 	std::vector<SelectionValue_t>  medium_vec;
 	std::vector<SelectionValue_t>  tight_vec;
 	std::vector<SelectionValue_t>  loose25nsRun2_vec;
 	std::vector<SelectionValue_t>  medium25nsRun2_vec;
 	std::vector<SelectionValue_t>  tight25nsRun2_vec;
-	std::auto_ptr<SelectionMap> looseMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> mediumMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> tightMap(new SelectionMap());
-	std::auto_ptr<SelectionMap> loose25nsRun2Map(new SelectionMap());
-	std::auto_ptr<SelectionMap> medium25nsRun2Map(new SelectionMap());
-	std::auto_ptr<SelectionMap> tight25nsRun2Map(new SelectionMap());
+	std::unique_ptr<SelectionMap> looseMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> mediumMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> tightMap(new SelectionMap());
+	std::unique_ptr<SelectionMap> loose25nsRun2Map(new SelectionMap());
+	std::unique_ptr<SelectionMap> medium25nsRun2Map(new SelectionMap());
+	std::unique_ptr<SelectionMap> tight25nsRun2Map(new SelectionMap());
 
 	//------------------------------ PHOTON
 	iEvent.getByLabel(photonsTAG, photonsHandle);
@@ -288,13 +288,13 @@ void PhoSelectionProducers::produce(edm::Event& iEvent, const edm::EventSetup& i
 
 	//------------------------------
 	// put the ValueMap in the event
-	iEvent.put(fiducialMap, "fiducial");
-	iEvent.put(looseMap, "loose");
-	iEvent.put(mediumMap, "medium");
-	iEvent.put(tightMap, "tight");
-	iEvent.put(loose25nsRun2Map, "loose25nsRun2");
-	iEvent.put(medium25nsRun2Map, "medium25nsRun2");
-	iEvent.put(tight25nsRun2Map, "tight25nsRun2");
+	iEvent.put(std::move(fiducialMap), "fiducial");
+	iEvent.put(std::move(looseMap), "loose");
+	iEvent.put(std::move(mediumMap), "medium");
+	iEvent.put(std::move(tightMap), "tight");
+	iEvent.put(std::move(loose25nsRun2Map), "loose25nsRun2");
+	iEvent.put(std::move(medium25nsRun2Map), "medium25nsRun2");
+	iEvent.put(std::move(tight25nsRun2Map), "tight25nsRun2");
 
 }
 

--- a/setup_git.sh
+++ b/setup_git.sh
@@ -10,8 +10,11 @@ checkVERSION(){
 			echo "[`basename $0` ERROR] $CMSSW_VERSION (2015 13TeV analysis) is not anymore supported by ECALELF"
 			exit 1
 			;;
-		 CMSSW_8_0_24_patch1)
+		CMSSW_8_0_24_patch1)
 			echo "[INFO] Installing for $CMSSW_VERSION (2016 13TeV)"
+			;;
+		CMSSW_9_2_0_patch5)
+			echo "[INFO] Installing for $CMSSW_VERSION (2017 13TeV)"
 			;;
 		*)
 			echo "[`basename $0` ERROR] Sorry, $CMSSW_VERSION not configured for ECALELF"
@@ -71,6 +74,9 @@ case $CMSSW_VERSION in
 		git cms-merge-topic 16790  || exit 1
 		git cms-merge-topic ikrav:egm_id_80X_v1 || exit 1
 		git cms-merge-topic shervin86:slewrate || exit 1
+		;;
+    CMSSW_9_2_*)
+	        echo "[STATUS] cms-merge-topics"
 		;;
 esac
 


### PR DESCRIPTION
Porting of `ECALELF` to CMSSW 92x. The code was successfully tested on `CMSSW_9_2_0_patch5` and `CMSSW_9_2_1`. Follow the instruction on the [README](https://github.com/yhaddad/ECALELF/blob/topic-portingto-92x/README.md) for the installation. 