### PR TITLE
fixed end of array error in ZNTupleDumper

### DIFF
--- a/ZNtupleDumper/plugins/ZNtupleDumper.cc
+++ b/ZNtupleDumper/plugins/ZNtupleDumper.cc
@@ -450,7 +450,6 @@ private:
 
 
 	eventType_t eventType;
-	unsigned int eventTypeCounter[DEBUG_T] = {0};
 
 	bool _isMINIAOD;
 };
@@ -577,10 +576,6 @@ void ZNtupleDumper::beginJob()
 		InitEleIDTree();
 	}
 
-	//for(int i = ZEE; i <= DEBUG_T && i <= 7; i++) {
-	//	eventTypeCounter[i] = 0;
-	//}
-
 #ifdef DEBUG
 	std::cout << "[DEBUG] End creation of ntuples" << std::endl;
 #endif
@@ -687,7 +682,6 @@ void ZNtupleDumper::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 			//}
 			//std::cout << "skip event: " << skipEvent << "\t" << eventType << std::endl;
 			//assert(!skipEvent);
-			eventTypeCounter[eventType]++;
 			if(skipEvent) return; // event not coming from any skim or paths
 		}
 	}
@@ -1064,11 +1058,6 @@ void ZNtupleDumper::endJob()
 		eleIDTree->Write();
 		eleIDTreeFile->Close();
 	}
-
-	std::cout << DEBUG_T << std::endl;
-//	for(size_t i = 0; i < 8; ++i) {
-//		std::cout << "[NTUPLEDUMPER] EventTypeCounter[" << i << "]\t" << eventTypeCounter[i] << std::endl;
-//	}
 }
 
 // ------------ method called when starting to processes a run  ------------
@@ -1310,7 +1299,6 @@ void ZNtupleDumper::TreeSetSingleElectronVar(const pat::Electron& electron, int 
 	assert(sc.isNonnull()); // at least one of the SCs has to be defined!
 
 	TreeSetSingleSCVar(*sc, index);
-
 	energy_ECAL_ele[index]			  = (_isMINIAOD) ? electron.correctedEcalEnergy()     : electron.userFloat("energySCEleMust");
 	energyUncertainty_ECAL_ele[index] = (_isMINIAOD) ? electron.correctedEcalEnergyError() : electron.userFloat("energySCEleMustVar");
 


### PR DESCRIPTION
Fixes #116 

eventTypeCounter goes over the end of the array
array was not used, so this commit removes it. 